### PR TITLE
Keep unparseable IEC URN docidentifiers verbatim instead of warning

### DIFF
--- a/lib/relaton/iec/model/docidentifier.rb
+++ b/lib/relaton/iec/model/docidentifier.rb
@@ -21,13 +21,7 @@ module Relaton
         parsed =
           case value
           when ::Pubid::Iec::Base then value
-          when String
-            begin
-              ::Pubid::Iec::Identifier.parse(value)
-            rescue StandardError
-              Util.warn "Failed to parse Pubid: #{value}"
-              nil
-            end
+          when String then parse_content(value)
           end
 
         if parsed
@@ -73,6 +67,19 @@ module Relaton
       end
 
       private
+
+      # Parse a string identifier into a Pubid object. IEC URNs use a positional
+      # format that pubid-iec cannot parse for amendments, series or
+      # consolidations. Those URNs are already in canonical ABNF form, so on a
+      # parse failure they are kept verbatim (as @raw_content) rather than warned
+      # about (relaton-iec#73, metanorma-pdfa#77); genuinely malformed non-URN
+      # identifiers still warn.
+      def parse_content(value)
+        ::Pubid::Iec::Identifier.parse(value)
+      rescue StandardError
+        Util.warn "Failed to parse Pubid: #{value}" unless value.start_with?("urn:")
+        nil
+      end
 
       def render_pubid(pubid)
         case type

--- a/spec/relaton/iec/model/docidentifier_spec.rb
+++ b/spec/relaton/iec/model/docidentifier_spec.rb
@@ -111,6 +111,68 @@ describe Relaton::Iec::Docidentifier do
     end
   end
 
+  describe "URN content" do
+    def build_urn(content)
+      described_class.new(content: content, type: "URN")
+    end
+
+    # metanorma-pdfa#77: an amendment URN cannot be parsed by pubid-iec, but it
+    # is already canonical, so it must be kept verbatim without a parse warning.
+    it "keeps an amendment URN verbatim without warning" do
+      docid = nil
+      expect { docid = build_urn("urn:iec:std:iec:61966-2-1:1999:::::amd:1:2003") }
+        .not_to output(/Failed to parse Pubid/).to_stderr_from_any_process
+      expect(docid.to_s).to eq "urn:iec:std:iec:61966-2-1:1999:::::amd:1:2003"
+    end
+
+    it "keeps a series URN without warning" do
+      docid = nil
+      expect { docid = build_urn("urn:iec:std:iec:80000:::ser") }
+        .not_to output(/Failed to parse Pubid/).to_stderr_from_any_process
+      # Exact rendering is pubid-iec's concern and differs across versions
+      # (1.15.20 re-emits a trailing colon); the fix only guarantees no warning.
+      expect(docid.to_s).to start_with "urn:iec:std:iec:80000:::ser"
+    end
+
+    it "keeps a consolidated (CSV) URN verbatim without warning" do
+      urn = "urn:iec:std:iec:60034-1:1969::csv:en-fr:plus:amd:1:1977:plus:amd:2:1979"
+      docid = nil
+      expect { docid = build_urn(urn) }
+        .not_to output(/Failed to parse Pubid/).to_stderr_from_any_process
+      expect(docid.to_s).to eq urn
+    end
+
+    it "parses a simple URN without warning" do
+      docid = nil
+      expect { docid = build_urn("urn:iec:std:iec:61058-2-4:1995") }
+        .not_to output(/Failed to parse Pubid/).to_stderr_from_any_process
+      expect(docid.pubid).not_to be_nil
+    end
+
+    it "warns and falls back to raw content for unparseable input" do
+      docid = nil
+      expect { docid = build_urn("this is not a valid id") }
+        .to output(/Failed to parse Pubid/).to_stderr_from_any_process
+      expect(docid.to_s).to eq "this is not a valid id"
+    end
+
+    # Regression for metanorma/metanorma-pdfa#77: deserializing a fetched
+    # bibitem with an amendment URN must not emit a parse warning.
+    it "does not warn when deserialized from XML (metanorma-pdfa#77)" do
+      xml = <<~XML
+        <bibitem type="standard" id="IEC61966-2-1">
+          <docidentifier type="IEC" primary="true">IEC 61966-2-1:1999/AMD1:2003</docidentifier>
+          <docidentifier type="URN">urn:iec:std:iec:61966-2-1:1999:::::amd:1:2003</docidentifier>
+        </bibitem>
+      XML
+      item = nil
+      expect { item = Relaton::Iec::Item.from_xml(xml) }
+        .not_to output(/Failed to parse Pubid/).to_stderr_from_any_process
+      urn = item.docidentifier.detect { |d| d.type == "URN" }
+      expect(urn.to_s).to eq "urn:iec:std:iec:61966-2-1:1999:::::amd:1:2003"
+    end
+  end
+
   describe "#to_all_parts!" do
     it "removes part and date from simple ID" do
       docid = build_docid("IEC 60027-1:1992")


### PR DESCRIPTION
## Problem

Fetching IEC bibitems logged a spurious warning for every amendment/series/consolidation URN:

```
[relaton-iec] WARN: Failed to parse Pubid: urn:iec:std:iec:61966-2-1:1999:::::amd:1:2003
```

Rendered PDF/HTML output was correct — the noise came from `Docidentifier#content=` handing the raw URN string to `Pubid::Iec::Identifier.parse`, which (in `pubid-iec` 1.15.x) cannot parse IEC amendment/series/CSV URNs. Reported as metanorma/metanorma-pdfa#77 (previously relaton/relaton-iec#73).

These URNs are already in the canonical IEC-URN ABNF form (verified against the IEC URN grammar), so there is nothing to "fix up" on render.

## Fix

Suppress the warning for URN strings that pubid can't parse and keep them **verbatim** (as raw content); genuinely malformed *non-URN* identifiers still warn. Rendering is left entirely to pubid.

```ruby
def parse_content(value)
  ::Pubid::Iec::Identifier.parse(value)
rescue StandardError
  Util.warn "Failed to parse Pubid: #{value}" unless value.start_with?("urn:")
  nil
end
```

This is minimal (no rendering changes) and **forward-compatible**: once a `pubid-iec` release parses these URNs, they simply flow through `pubid.urn` (which is canonical for amendments/CSV in 1.15.20 and for series on the upstream v1 branch).

## Tests

New `URN content` context in `docidentifier_spec.rb`: amendment/series/CSV kept without warning, simple URN still parses, unparseable input still warns, and an XML-deserialization regression test for #77. The assertions target the real invariant — **no spurious warning** — rather than pubid's version-dependent URN rendering.

Verified green across `pubid-iec` **1.15.18**, released **1.15.20**, and the upstream **v1** branch:

```
157 examples, 0 failures
```